### PR TITLE
chore(#3): DB 설계 고정 데이터들 ENUM으로 변경

### DIFF
--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,177 @@
+CREATE TABLE IF NOT EXISTS `airbnb`.`user`
+(
+    `id`           BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `email`        VARCHAR(50)     NOT NULL,
+    `password`     VARCHAR(50)     NOT NULL,
+    `name`         VARCHAR(50)     NOT NULL,
+    `gender`       VARCHAR(10),
+    `phone_number` VARCHAR(20),
+    `address`      VARCHAR(200),
+    `is_active`    BOOLEAN   DEFAULT TRUE, -- 활성화 유저인가? 아닌가?
+    `birthdate`    TIMESTAMP,
+    `created_at`   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    `updated_at`   TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `deleted_at`   TIMESTAMP,
+
+    PRIMARY KEY (`id`)
+) ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS `airbnb`.`host`
+(
+    `id`          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `photo_url`   VARCHAR(200),
+    `description` VARCHAR(200),
+
+    `user_id`     BIGINT UNSIGNED NOT NULL,
+
+    PRIMARY KEY (`id`),
+    KEY `user_id-idx` (`user_id`)
+) ENGINE = InnoDB;
+
+
+CREATE TABLE IF NOT EXISTS `airbnb`.`room_category`
+(
+    `id`               BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `root_category`    VARCHAR(20)     NOT NULL,
+    `reaf_category`    VARCHAR(20)     NOT NULL,
+    -- WHOLE[집 전체] : 게스트가 침실, 욕실, 주방을 비롯한 숙소 전체 공간을 단독으로 사용합니다.
+    -- PRIVATE[개인실] : 게스트가 일부 공간을 다른 사람과 공유하나 침실은 단독으로 사용합니다.
+    -- SHARED[다인실] : 게스트가 침실을 단독으로 사용하지 않습니다.
+    `room_type`        VARCHAR(20)     NOT NULL,
+    `is_several_rooms` BOOLEAN         NOT NULL,
+
+    PRIMARY KEY (`id`)
+) ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS `airbnb`.`room`
+(
+    `id`                   BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `title`                VARCHAR(50)     NOT NULL,
+    `description`          TEXT            NOT NULL,
+    `bed_count`            INT UNSIGNED    NOT NULL,           -- 침대 수
+    `bedroom_count`        INT UNSIGNED    NOT NULL,           -- 침실 수
+    `bathroom_count`       INT UNSIGNED    NOT NULL,           -- 욕실 수
+    `limit_guests`         INT UNSIGNED    NOT NULL,           -- 최대 게스트 수
+    `min_number_of_nights` INT UNSIGNED    NOT NULL,           -- 최소 숙박 일수
+    `max_number_of_nights` INT UNSIGNED    NOT NULL,           -- 최대 숙박 일수
+    `room_count`           INT UNSIGNED    NOT NULL DEFAULT 1, -- 방의 개수
+    `check_in`             VARCHAR(2)      NOT NULL,           -- 체크인 시간
+    `check_out`            VARCHAR(2)      NOT NULL,           -- 체크아웃 시간
+    `address`              VARCHAR(200),
+    -- content, description 종류 3가지
+    -- IN_OPERATION : 영업 중, 게스트가 숙소를 검색하고 예약 요청을 보내거나 예약 가능 날짜를 예약할 수 있습니다.
+    -- SHUT_DOWN : 운영 중지, 게스트가 숙소를 예약하거나 검색 결과에서 찾을 수 없습니다.
+    -- DISABLED : 비활성화, 에어비앤비에서 영구적으로 숙소 비활성화
+    `status`               VARCHAR(20)     NOT NULL,
+    `created_at`           TIMESTAMP                DEFAULT CURRENT_TIMESTAMP,
+    `updated_at`           TIMESTAMP                DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `deleted_at`           TIMESTAMP,                          -- Soft Delete
+
+    `host_id`              BIGINT UNSIGNED NOT NULL,
+    `room_category_id`     BIGINT UNSIGNED NOT NULL,
+
+    PRIMARY KEY (`id`),
+    KEY `host_id-idx` (`host_id`),
+    KEY `room_category_id-idx` (`room_category_id`)
+) ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS `airbnb`.`room_reservation`
+(
+    `id`          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `user_count`  INT UNSIGNED    NOT NULL, -- 예약 게스트 수
+    `total_price` INT UNSIGNED    NOT NULL, -- 예약 가격
+    `start_date`  TIMESTAMP       NOT NULL,
+    `end_date`    TIMESTAMP       NOT NULL,
+    `created_at`  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    `updated_at`  TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `deleted_at`  TIMESTAMP,                -- Soft Delete
+
+    `user_id`     BIGINT UNSIGNED NOT NULL,
+    `room_id`     BIGINT UNSIGNED NOT NULL,
+
+    PRIMARY KEY (`id`),
+    KEY `user_id-idx` (`user_id`),
+    KEY `room_id-idx` (`room_id`)
+) ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS `airbnb`.`wish_room`
+(
+    `id`         BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    `deleted_at` TIMESTAMP, -- Soft Delete
+
+    `user_id`    BIGINT UNSIGNED NOT NULL,
+    `room_id`    BIGINT UNSIGNED NOT NULL,
+
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `wish_room-unique` (`user_id`, `room_id`),
+    KEY `user_id-idx` (`user_id`),
+    KEY `room_id-idx` (`room_id`)
+) ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS `airbnb`.`room_review`
+(
+    `id`         BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `content`    TEXT            NOT NULL,
+    `like`       INT UNSIGNED    NOT NULL, -- 좋아요 1~5점 [에어비앤비는 좋아요가 아니고 5개정도? 있지만 현 프로젝트는 "좋아요" 하나로만]
+    `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `deleted_at` TIMESTAMP,                -- Soft Delete
+
+    `room_id`    BIGINT UNSIGNED NOT NULL,
+    `user_id`    BIGINT UNSIGNED NOT NULL,
+
+    PRIMARY KEY (`id`),
+    KEY `room_id-idx` (`room_id`),
+    KEY `user_id-idx` (`user_id`)
+) ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS `airbnb`.`facility`
+(
+    `id`          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `category`    VARCHAR(20)     NOT NULL,
+    `name`        VARCHAR(20)     NOT NULL,
+    `description` VARCHAR(50) DEFAULT NULL,
+
+    PRIMARY KEY (`id`)
+) ENGINE = InnoDB;
+
+-- 다대다 테이블임을 명시적으로 보여주기 위해 "__"를 중간에 넣음
+CREATE TABLE IF NOT EXISTS `airbnb`.`room__facility`
+(
+    `id`          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+
+    `room_id`     BIGINT UNSIGNED NOT NULL,
+    `facility_id` BIGINT UNSIGNED NOT NULL,
+
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `room__facility-unique` (`room_id`, `facility_id`), -- 특정 방에 대해서 편의시설 중복 방지
+    KEY `room_id-idx` (`room_id`),
+    KEY `facility_id-idx` (`facility_id`)
+) ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS `airbnb`.`room_photo`
+(
+    `id`      BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `url`     VARCHAR(255)    NOT NULL,
+    `order`   INT UNSIGNED, -- 방에서 보여줄 사진의 우선순위 설정
+
+    `room_id` BIGINT UNSIGNED NOT NULL,
+
+    PRIMARY KEY (`id`),
+    KEY `room_id-idx` (`room_id`)
+) ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS `airbnb`.`room_price`
+(
+    `id`                    BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `month`                 INT UNSIGNED    NOT NULL, -- 1,2,3,4,5,6,7,8,9,10,11,12 월
+    `price`                 INT UNSIGNED    NOT NULL, -- 월별 기본 가격
+    `weekly_discount_price` INT UNSIGNED    NOT NULL, -- 월별 주간 할인 가격
+    `currency`              VARCHAR(20)     NOT NULL,
+
+    `room_id`               BIGINT UNSIGNED NOT NULL,
+
+    PRIMARY KEY (`id`),
+    KEY `room_id-idx` (`room_id`)
+) ENGINE = InnoDB;


### PR DESCRIPTION
- category 관련 테이블 모두 room_category 테이블로 묶음
- facility_category 테이블은 facilitry 테이블의 category 컬럼으로 넣음
- 고정 데이터들은 자바 애플리케이션 단에서 ENUM으로 관리하기로 결정

![airjnc-ERD](https://user-images.githubusercontent.com/41284492/174228646-70d3c502-0987-4883-ae1c-ff2f6bbc6223.png)
# Related Issues
- Resolved #3 

# Description

### COMMON
1. DELETE 매커니즘은 HardDelete가 아닌 SoftDelete로 진행했습니다.
   - `deletedAt` 컬럼 사용
2. 시간 관련 타입은 "DATETIME, DATE" 칼럼이 아닌 "TIMESTAMP"로 통일했습니다.
   - 시간 관련 타입을 여러 개의 종류를 섞어서 쓸 경우, 시간 관련 데이터를 조작할 때 혼란이 올 가능성이 있기 때문입니다.
   - "DATETIME, DATE" 같은 경우는 DB 커넥션 타임존에 관계없이 클라이언트로부터 입력된 값을 그대로 저장하고, TIMESTAMP같은 경우는 타임존에 따라 시간이 보정됩니다. 이로 인해 두 가지의 데이터 타입을 섞어 쓸 경우, 어느 API는 시간을 보정하는 로직이 생기고, 어느 API는 시간을 보정하는 로직이 생기지 않는 상황을 방지하기 위해 날짜 데이터 타입을 하나로 통일했고, TIMESTAMP로 통일했습니다.
4. 외래키 같은 경우엔 제약을 걸지 않았습니다.
   - 외래키 제약을 걸 경우, 데이터 일관성과 그에 따른 제약 때문에 성능 이슈가 발생할 수 있기 때문에 외래키를 물리적으로 제약 걸지 않았습니다.
   - 외래키를 물리적으로 제약을 걸지 않았고, 해당 외래키에 대해서는 하나하나씩 인덱스를 생성했습니다. 왜냐하면, 외래키같은 경우 JOIN문으로 사용할 경우가 아주 많이 발생하는데, JOIN 문에서 성능 최적화를 위해서는 INNER TABLE의 조인키에 인덱스가 있어야 하기 때문입니다.
5. 다대다 테이블의 이름 같은 경우, 해당 테이블이 다대다 테이블임을 명시하기 위해 중간에 "__"를 넣었고 양 옆에 연결되는 테이블을 적었습니다.
    - Ex) `room_category_dateil__room_type`, `room__room_facility`
6. 다대다 테이블에서 유니크 제약을 걸었습니다.
    - `room_category_detail__room_type` 테이블에선, `room_category_detail_id`와 `room_type_id`를 한 쌍으로 유니크 제약을 걸었습니다.
    - `room__room_facilitiy` 테이블에선, `room_id`와 `facility_id` 를 한 쌍으로 유니크 제약을 걸었습니다.
    - 유니크 제약을 건 이유 -> MySQL의 InnoDB 에서는 PK가 물리적으로 디스크상에서 저장시 정렬하면서 저장됩니다. 다대다 테이블에서 PK를 2개의 로우에 대해서 걸어버릴 경우, 데이터 저장시 소팅되면서 저장되는 성능 이슈가 발생할 수 있습니다. 때문에 PK를 2개의 로우에 대해서 설정하지 않았고, 자동 증가 값인 `AUTO_INCREMENT`를 통해 설정했습니다. 이렇게 설정할 경우, 기본에 row 2개에 대해서 PK를 걸어버리는 상황과 달리 중복 이슈가 발생할 수 있습니다. "`room__room_facility`를 예로 들면, 방 하나에 대해서 동일한 편의시설이 저장되는 등.." 이러한 중복 이슈를 방지하기 위해 유니크 제약을 걸었습니다.
### [TABLE] host 

1. 유저 별로 여러 개의 호스트를 가질 수 있기 때문에, `host` Table을 따로 뺐습니다. [1:다 관계]

### [TABLE] user
1. `is_active` -> 활성화 여부를 판단
2. `gender` -> 성별
    - 해당 컬럼은 향후로도 남자/여자 외에는 데이터 추가할 일이 전혀 없을 것 같으므로, 테이블을 따로 빼서 참조하는 식으로 설계하지 않았고 VARCHAR 타입으로 설계 이후, 애플리케이션 단에서 데이터 규격을 잡아 저장합니다.

 ### [TABLE] room
1. `(min/max)_number_of_nights` -> 최소 숙박 일수, 최대 숙박 일수
    - 사용자는 명시한 최소 숙박 일수 이상으로만 예약할 수 있습니다.
    - 사용자는 명시한 최대 숙박 일수 이하로만 예약할 수 있습니다.
5. `room_cnt` -> 해당 방에 대한 개수
   -  명시적으로 설정하지 않을 경우, DEFAULT 값은 1입니다.
   - 방의 카테고리에는 "호텔"이 존재합니다. 어떠한 특정 카테고리에서는 방을 1개만 제공하는 서비스가 아닌 2개 이상을 제공할 수 있습니다. 때문에, 방의 개수를 지정할 컬럼을 추가했습니다.
   - "호텔"같은 여러 방을 제공하는 카테고리가 아닌, 단순히 저택같은 경우 해당 컬럼의 값은 1입니다.
7. `check_in`, `check_out`
    - 해당 방의 체크인/체크아웃 시간입니다.
    - 해당 컬럼같은 경우, 날짜[2022/06/15 같은]의 존재가 필요없고, 또한 저희 기능상으론 체크인/체크아웃에 분단위[30분 같은]가 들어가지 않습니다.
    - 최종적으로, 체크인/체크아웃은 "시간"단위로만 입력되기 때문에, 날짜타입[TIMESTAMP]가 아닌 VARCHAR 타입으로 설정했으며 이 경우, 저장시에는 "11"->11시(or)"15"->15시 형태로 저장됩니다.

### [TABLE] room_price
1. 특정 방에 대해서 월별로 가격을 설정하는 기능을 구현하기 위해 1:다 테이블로 설계했습니다.
2. `price` 는 해당 월[ex)month=1이면 1월]에 대한 기본 가격이며, `weekly_price` 는 주간 할인 가격입니다.

### [TABLE] room_status
**특정 방에 대한 상태값을 저장하는 테이블입니다.**
1. 현재 초기 기능 요구서에서 나온 상태값은 총 3개입니다.
   - IN_OPERATION : 영업 중, 게스트가 숙소를 검색하고 예약 요청을 보내거나 예약 가능 날짜를 예약할 수 있습니다
   - SHUT_DOWN : 운영 중지, 게스트가 숙소를 예약하거나 검색 결과에서 찾을 수 없습니다.
   - DISABLED : 비활성화, 에어비앤비에서 영구적으로 숙소 비활성화
2. 방에 대한 상태값을 초기 기능 요구서에서 정의한 상태값에서, 추후에 추가될 가능성이 높기 때문에 테이블을 따로 빼서 참조하게끔 했습니다.

### [TABLE] room_photo
**방에 대한 사진**
1. `order` -> 방에서 노출시키는 사진에 대한 우선순위

### [TABLE] room__room_faciltiy / room_facility / room_faciltiy_category
1. `room_facility_category`
    - 해당 테이블을 통해 편의시설에 대한 카테고리를 설정합니다.
4. `room_faciltiry`
    - 편의시설에 대한 이름과 설명을 저장하는 테이블입니다.
5. `room__room_facility`
    - 방은 여러 개의 편의시설을 가질 수 있고, 편의시설 또한 여러 개의 방을 가질 수 있습니다. 때문에, 다대다 테이블로 설정했습니다.
    - 방-편의시설을 "일:다"로 설계할 경우, 편의시설에 "드라이기"라는 아이템이 있을 경우 room_facility 테이블에서 "드라이기__roomId-1, 드라이기__roomId-2, 드라이기__romId-3" 으로 저장됩니다. 이 경우, 만약 "드라이기"라는 아이템의 이름을 변경해야 할 때는 "드라이기"의 모든 row에 대해서 이름을 변경해야 하기 때문에 변경지점이 한 곳이 아닌, 여러 개가 되어버립니다. 이를 방지하기 위해 다대다 테이블로 설계했습니다.

### [TABLE] room_category / room_category_detail / room_type / room_category_detail__room_type
![Screen Shot 2022-06-15 at 5 09 04 PM](https://user-images.githubusercontent.com/41284492/173776505-e333a686-8890-497d-bdc7-42f793faf2ad.png)
![Screen Shot 2022-06-15 at 5 09 14 PM](https://user-images.githubusercontent.com/41284492/173776522-101ddf99-49ca-46c2-849c-5dc99c86ac4f.png)
1. `room_category` -> "회원님의 숙소에 가장 적합한 유형을 선택하세요"에서 나오는 값들을 저장하는 테이블
2. `room_category_detail` -> 첫 번째 숙소 유형에 나오는 값들을 저장하는 테이블
    - `room_category` 와 일:다 테이블여야 하는 이유 -> 가장 적합한 유형[`room_category`의 값]에 따라 나오는 값들이 다르기 때문
3. `room_type` -> 두 번째 숙소 유형에 나오는 값들을 저장하는 테이블
    - "전체/개인실/다인실" 3개의 데이터만 존재한다.
5. `room_category_detail__room_type` -> 첫 번째 숙소 유형과 두 번째 숙소 유형을 연결짓는 테이블
    - 첫 번째 숙소 유형과 달리 "다:다"테이블이 있는 이유 -> 두 번째 숙소 유형은 첫 번째 숙소 유형과는 달리, 테이블이 여러 개 존재하지도 않고, 상위 테이블에 따라 데이터가 달라지지 않는다. 두 번째 숙소 유형의 값 같은 경우 "전체/개인실/다인실" 3개 고정으로만 존재하며, 이를 사용하기 때문
    - 첫 번째 숙소 유형에 나오는 값들과는 달리, "전체/개인실/다인실"로 고정이 되어 있고, 첫 번째 숙소 유형에 따라 "전체/개인실"만 있을 수도 있고 "전체/개인실/다인실" 전체가 있을 수도 있고, "다인실"만 있을 수 있다. 때문에, "전체/개인실/다인실" 3개의 row를 `room_type` 에서 생성하고, 이를 `room_category_detail` 이 가져다 사용하는 방식으로 진행합니다.

# 변경 사항

main/java/resources에 `schema.sql` 파일 추가

# 질문 사항

# 기타


# (Optaionl) 어떻게 테스트하셨나요?

