### PR TITLE
사용하지 않는 User Table의 컬럼들 제거 & 시간 관련 필드들 `CommonTimeEntity` 클래스로 뺐음

### DIFF
--- a/docker/schema.sql
+++ b/docker/schema.sql
@@ -7,7 +7,6 @@ CREATE TABLE IF NOT EXISTS `user`
     `gender`       VARCHAR(10),
     `phone_number` VARCHAR(20),
     `address`      VARCHAR(200),
-    `is_active`    BOOLEAN   DEFAULT TRUE, -- 활성화 유저인가? 아닌가?
     `birthdate`    TIMESTAMP,
     `created_at`   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     `updated_at`   TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/docker/schema.sql
+++ b/docker/schema.sql
@@ -5,7 +5,6 @@ CREATE TABLE IF NOT EXISTS `user`
     `password`     VARCHAR(100)    NOT NULL,
     `name`         VARCHAR(50)     NOT NULL,
     `gender`       VARCHAR(10),
-    `phone_number` VARCHAR(20),
     `address`      VARCHAR(200),
     `birthdate`    TIMESTAMP,
     `created_at`   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -13,8 +12,7 @@ CREATE TABLE IF NOT EXISTS `user`
     `deleted_at`   TIMESTAMP,
 
     PRIMARY KEY (`id`),
-    UNIQUE KEY `email-unique` (`email`),
-    UNIQUE KEY `phone_number-unique` (`phone_number`)
+    UNIQUE KEY `email-unique` (`email`)
 ) ENGINE = InnoDB;
 
 CREATE TABLE IF NOT EXISTS `host`

--- a/src/main/java/com/airjnc/common/entity/CommonTimeEntity.java
+++ b/src/main/java/com/airjnc/common/entity/CommonTimeEntity.java
@@ -1,0 +1,25 @@
+package com.airjnc.common.entity;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+public class CommonTimeEntity {
+
+  private LocalDateTime createdAt;
+
+  private LocalDateTime updatedAt;
+
+  private LocalDateTime deletedAt;
+
+  public void delete() {
+    this.deletedAt = LocalDateTime.now(Clock.systemUTC());
+  }
+
+  public boolean isDeleted() {
+    return deletedAt != null;
+  }
+
+  public void restore() {
+    this.deletedAt = null;
+  }
+}

--- a/src/main/java/com/airjnc/user/domain/UserEntity.java
+++ b/src/main/java/com/airjnc/user/domain/UserEntity.java
@@ -1,5 +1,6 @@
 package com.airjnc.user.domain;
 
+import com.airjnc.common.entity.CommonTimeEntity;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -14,7 +15,7 @@ import lombok.ToString;
 @Setter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @ToString
-public class UserEntity {
+public class UserEntity extends CommonTimeEntity {
 
   private Long id;
 
@@ -34,11 +35,6 @@ public class UserEntity {
 
   private LocalDate birthDate;
 
-  private LocalDateTime createdAt;
-
-  private LocalDateTime updatedAt;
-
-  private LocalDateTime deletedAt;
 
   @Builder
   public UserEntity(Long id, String email, String password, String name, Gender gender, String phoneNumber,
@@ -52,17 +48,5 @@ public class UserEntity {
     this.address = address;
     this.isActive = true;
     this.birthDate = birthDate;
-  }
-
-  public void delete() {
-    this.deletedAt = LocalDateTime.now(Clock.systemUTC());
-  }
-
-  public boolean isDeleted() {
-    return deletedAt != null;
-  }
-
-  public void restore() {
-    this.deletedAt = null;
   }
 }

--- a/src/main/java/com/airjnc/user/domain/UserEntity.java
+++ b/src/main/java/com/airjnc/user/domain/UserEntity.java
@@ -1,9 +1,7 @@
 package com.airjnc.user.domain;
 
 import com.airjnc.common.entity.CommonTimeEntity;
-import java.time.Clock;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -35,16 +33,15 @@ public class UserEntity extends CommonTimeEntity {
 
   private LocalDate birthDate;
 
-
   @Builder
-  public UserEntity(Long id, String email, String password, String name, Gender gender, String phoneNumber,
+  public UserEntity(Long id, String email, String phoneNumber, String password, String name, Gender gender,
       String address, LocalDate birthDate) {
     this.id = id;
     this.email = email;
+    this.phoneNumber = phoneNumber;
     this.password = password;
     this.name = name;
     this.gender = gender;
-    this.phoneNumber = phoneNumber;
     this.address = address;
     this.isActive = true;
     this.birthDate = birthDate;

--- a/src/main/java/com/airjnc/user/domain/UserEntity.java
+++ b/src/main/java/com/airjnc/user/domain/UserEntity.java
@@ -29,8 +29,6 @@ public class UserEntity extends CommonTimeEntity {
 
   private String address;
 
-  private Boolean isActive;
-
   private LocalDate birthDate;
 
   @Builder
@@ -43,7 +41,6 @@ public class UserEntity extends CommonTimeEntity {
     this.name = name;
     this.gender = gender;
     this.address = address;
-    this.isActive = true;
     this.birthDate = birthDate;
   }
 }

--- a/src/main/java/com/airjnc/user/domain/UserEntity.java
+++ b/src/main/java/com/airjnc/user/domain/UserEntity.java
@@ -19,8 +19,6 @@ public class UserEntity extends CommonTimeEntity {
 
   private String email;
 
-  private String phoneNumber;
-
   private String password;
 
   private String name;
@@ -32,11 +30,10 @@ public class UserEntity extends CommonTimeEntity {
   private LocalDate birthDate;
 
   @Builder
-  public UserEntity(Long id, String email, String phoneNumber, String password, String name, Gender gender,
+  public UserEntity(Long id, String email, String password, String name, Gender gender,
       String address, LocalDate birthDate) {
     this.id = id;
     this.email = email;
-    this.phoneNumber = phoneNumber;
     this.password = password;
     this.name = name;
     this.gender = gender;

--- a/src/main/java/com/airjnc/user/dto/UserWhereDto.java
+++ b/src/main/java/com/airjnc/user/dto/UserWhereDto.java
@@ -22,15 +22,13 @@ public class UserWhereDto {
 
   private final String address;
 
-  private final Boolean isActive;
-
   private final LocalDate birthDate;
 
   private final UserStatus status;
 
   @Builder
   public UserWhereDto(Long id, String email, String phoneNumber, String name, Gender gender, String address,
-      LocalDate birthDate, boolean isActive, UserStatus status) {
+      LocalDate birthDate, UserStatus status) {
     if (id == null && email == null && phoneNumber == null && name == null && birthDate == null) {
       throw new DefaultException(ErrorsFactory.createAndReject("dangerousQuery"));
     }
@@ -41,7 +39,6 @@ public class UserWhereDto {
     this.gender = gender;
     this.address = address;
     this.birthDate = birthDate;
-    this.isActive = isActive;
     this.status = status;
   }
 

--- a/src/main/java/com/airjnc/user/dto/UserWhereDto.java
+++ b/src/main/java/com/airjnc/user/dto/UserWhereDto.java
@@ -14,8 +14,6 @@ public class UserWhereDto {
 
   private final String email;
 
-  private final String phoneNumber;
-
   private final String name;
 
   private final Gender gender;
@@ -27,14 +25,13 @@ public class UserWhereDto {
   private final UserStatus status;
 
   @Builder
-  public UserWhereDto(Long id, String email, String phoneNumber, String name, Gender gender, String address,
+  public UserWhereDto(Long id, String email, String name, Gender gender, String address,
       LocalDate birthDate, UserStatus status) {
-    if (id == null && email == null && phoneNumber == null && name == null && birthDate == null) {
+    if (id == null && email == null && name == null && birthDate == null) {
       throw new DefaultException(ErrorsFactory.createAndReject("dangerousQuery"));
     }
     this.id = id;
     this.email = email;
-    this.phoneNumber = phoneNumber;
     this.name = name;
     this.gender = gender;
     this.address = address;

--- a/src/main/java/com/airjnc/user/dto/response/UserInquiryEmailResp.java
+++ b/src/main/java/com/airjnc/user/dto/response/UserInquiryEmailResp.java
@@ -11,15 +11,12 @@ public class UserInquiryEmailResp {
 
   private final String email;
 
-  private final Boolean isActive;
-
   private final LocalDateTime deletedAt;
 
   @Builder
-  public UserInquiryEmailResp(Long id, String email, boolean isActive, LocalDateTime deletedAt) {
+  public UserInquiryEmailResp(Long id, String email, LocalDateTime deletedAt) {
     this.id = id;
     this.email = email;
-    this.isActive = isActive;
     this.deletedAt = deletedAt;
   }
 }

--- a/src/main/java/com/airjnc/user/dto/response/UserResp.java
+++ b/src/main/java/com/airjnc/user/dto/response/UserResp.java
@@ -21,22 +21,19 @@ public class UserResp {
 
   private final String address;
 
-  private final Boolean isActive;
-
   private final LocalDate birthDate;
 
   private final LocalDateTime deletedAt;
 
   @Builder
   public UserResp(Long id, String email, String name, Gender gender, String phoneNumber, String address,
-      boolean isActive, LocalDate birthDate, LocalDateTime deletedAt) {
+      LocalDate birthDate, LocalDateTime deletedAt) {
     this.id = id;
     this.email = email;
     this.name = name;
     this.gender = gender;
     this.phoneNumber = phoneNumber;
     this.address = address;
-    this.isActive = isActive;
     this.birthDate = birthDate;
     this.deletedAt = deletedAt;
   }

--- a/src/main/java/com/airjnc/user/dto/response/UserResp.java
+++ b/src/main/java/com/airjnc/user/dto/response/UserResp.java
@@ -13,8 +13,6 @@ public class UserResp {
 
   private final String email;
 
-  private final String phoneNumber;
-
   private final String name;
 
   private final Gender gender;
@@ -26,13 +24,12 @@ public class UserResp {
   private final LocalDateTime deletedAt;
 
   @Builder
-  public UserResp(Long id, String email, String name, Gender gender, String phoneNumber, String address,
+  public UserResp(Long id, String email, String name, Gender gender, String address,
       LocalDate birthDate, LocalDateTime deletedAt) {
     this.id = id;
     this.email = email;
     this.name = name;
     this.gender = gender;
-    this.phoneNumber = phoneNumber;
     this.address = address;
     this.birthDate = birthDate;
     this.deletedAt = deletedAt;

--- a/src/main/resources/mybatis/mapper/user.xml
+++ b/src/main/resources/mybatis/mapper/user.xml
@@ -14,7 +14,6 @@
     <where>
       <if test="id != null">AND id = #{id}</if>
       <if test="email != null">AND email = #{email}</if>
-      <if test="phoneNumber != null">AND phone_number = #{phoneNumber}</if>
       <if test="name != null">AND name = #{name}</if>
       <if test="gender != null">AND gender = #{gender}</if>
       <if test="address != null">AND address = #{address}</if>
@@ -24,27 +23,26 @@
   </sql>
 
   <insert id="create" keyProperty="id" useGeneratedKeys="true">
-    INSERT INTO user (email, phone_number, password, name, gender, address, birthdate)
-    VALUES (#{email}, #{phoneNumber}, #{password}, #{name}, #{gender}, #{address}, #{birthDate})
+    INSERT INTO user (email, password, name, gender, address, birthdate)
+    VALUES (#{email}, #{password}, #{name}, #{gender}, #{address}, #{birthDate})
   </insert>
   <select id="exists" resultType="boolean">
     SELECT EXISTS(SELECT 1 FROM user<include refid="where"/>)
   </select>
   <select id="findById" resultType="UserEntity">
-    SELECT id, email, name, gender, phone_number, address, birthdate, created_at, updated_at, deleted_at
+    SELECT id, email, name, gender, address, birthdate, created_at, updated_at, deleted_at
     FROM user
     WHERE id = #{id}
     <include refid="checkStatus"/>
   </select>
   <select id="findByWhere" resultType="UserEntity">
-    SELECT id, email, name, gender, phone_number, address, birthdate, created_at, updated_at, deleted_at
+    SELECT id, email, name, gender, address, birthdate, created_at, updated_at, deleted_at
     FROM user
     <include refid="where"/>
   </select>
   <update id="save">
     UPDATE user
     SET email=#{email},
-        phone_number=#{phoneNumber},
         password=#{password},
         name=#{name},
         gender=#{gender},

--- a/src/main/resources/mybatis/mapper/user.xml
+++ b/src/main/resources/mybatis/mapper/user.xml
@@ -31,13 +31,13 @@
     SELECT EXISTS(SELECT 1 FROM user<include refid="where"/>)
   </select>
   <select id="findById" resultType="UserEntity">
-    SELECT id, email, name, gender, phone_number, address, is_active, birthdate, created_at, updated_at, deleted_at
+    SELECT id, email, name, gender, phone_number, address, birthdate, created_at, updated_at, deleted_at
     FROM user
     WHERE id = #{id}
     <include refid="checkStatus"/>
   </select>
   <select id="findByWhere" resultType="UserEntity">
-    SELECT id, email, name, gender, phone_number, address, is_active, birthdate, created_at, updated_at, deleted_at
+    SELECT id, email, name, gender, phone_number, address, birthdate, created_at, updated_at, deleted_at
     FROM user
     <include refid="where"/>
   </select>
@@ -50,7 +50,6 @@
         gender=#{gender},
         address=#{address},
         birthdate=#{birthDate},
-        is_active=#{isActive},
         deleted_at=#{deletedAt}
     WHERE id = #{id}
   </update>

--- a/src/test/java/com/airjnc/user/controller/UserControllerTest.java
+++ b/src/test/java/com/airjnc/user/controller/UserControllerTest.java
@@ -111,7 +111,7 @@ class UserControllerTest {
     //given
     UserInquiryEmailReq req = UserInquiryEmailReq.builder().name(TestUser.NAME).birthDate(TestUser.BIRTH_DATE).build();
     UserInquiryEmailResp resp = UserInquiryEmailResp.builder()
-        .id(TestUser.ID).email(TestUser.EMAIL).isActive(TestUser.IS_ACTIVE).deletedAt(TestUser.CREATED_AT).build();
+        .id(TestUser.ID).email(TestUser.EMAIL).deletedAt(TestUser.CREATED_AT).build();
     UserResp userResp = UserRespFixture.getBuilder().build();
     given(userService.getUserByWhere(any(UserWhereDto.class))).willReturn(userResp);
     given(userModelMapper.userRespToUserInquiryEmailResp(userResp)).willReturn(resp);

--- a/src/test/java/com/testutil/config/TestDatabaseConfig.java
+++ b/src/test/java/com/testutil/config/TestDatabaseConfig.java
@@ -40,8 +40,8 @@ public class TestDatabaseConfig {
   private void initData(DriverManagerDataSource dataSource) {
     JdbcTemplate template = new JdbcTemplate(dataSource);
     String sql =
-        "insert into `user` (id, email, password, name, gender, phone_number, address, is_active, birthdate, created_at, updated_at) "
-            + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        "insert into `user` (id, email, password, name, gender, address, birthdate) "
+            + "VALUES (?, ?, ?, ?, ?, ?, ?)";
     UserEntity user = TestUser.getBuilder().build();
     template.update(
         sql,
@@ -50,12 +50,8 @@ public class TestDatabaseConfig {
         user.getPassword(),
         user.getName(),
         user.getGender().name(),
-        user.getPhoneNumber(),
         user.getAddress(),
-        user.getIsActive(),
-        user.getBirthDate(),
-        user.getCreatedAt(),
-        user.getUpdatedAt()
+        user.getBirthDate()
     );
   }
 }

--- a/src/test/java/com/testutil/fixture/user/UserRespFixture.java
+++ b/src/test/java/com/testutil/fixture/user/UserRespFixture.java
@@ -18,8 +18,6 @@ public class UserRespFixture {
 
   public static final String ADDRESS = "서울 강남구";
 
-  public static final Boolean IS_ACTIVE = true;
-
   public static final LocalDate BIRTH_DATE = LocalDate.of(2000, 5, 15);
 
   public static UserResp.UserRespBuilder getBuilder() {
@@ -30,7 +28,6 @@ public class UserRespFixture {
         .gender(GENDER)
         .phoneNumber(PHONE_NUMBER)
         .address(ADDRESS)
-        .isActive(IS_ACTIVE)
         .birthDate(BIRTH_DATE);
   }
 }

--- a/src/test/java/com/testutil/fixture/user/UserRespFixture.java
+++ b/src/test/java/com/testutil/fixture/user/UserRespFixture.java
@@ -14,8 +14,6 @@ public class UserRespFixture {
 
   public static final Gender GENDER = Gender.MALE;
 
-  public static final String PHONE_NUMBER = "010-1111-2222";
-
   public static final String ADDRESS = "서울 강남구";
 
   public static final LocalDate BIRTH_DATE = LocalDate.of(2000, 5, 15);
@@ -26,7 +24,6 @@ public class UserRespFixture {
         .email(EMAIL)
         .name(NAME)
         .gender(GENDER)
-        .phoneNumber(PHONE_NUMBER)
         .address(ADDRESS)
         .birthDate(BIRTH_DATE);
   }

--- a/src/test/java/com/testutil/testdata/TestUser.java
+++ b/src/test/java/com/testutil/testdata/TestUser.java
@@ -17,11 +17,7 @@ public class TestUser {
 
   public static final Gender GENDER = Gender.MALE;
 
-  public static final String PHONE_NUMBER = "01011112222";
-
   public static final String ADDRESS = "서울 강남구";
-
-  public static final Boolean IS_ACTIVE = true;
 
   public static final LocalDate BIRTH_DATE = LocalDate.of(2020, 1, 1);
 
@@ -34,7 +30,6 @@ public class TestUser {
         .password(PASSWORD)
         .name(NAME)
         .gender(GENDER)
-        .phoneNumber(PHONE_NUMBER)
         .address(ADDRESS)
         .birthDate(BIRTH_DATE);
   }


### PR DESCRIPTION
### Related Issues

- Resolved #(issue)

# Description

- 사용하지 않는 User Table을 제거하여 복잡성을 감소
- 여러 `Entity` 에서 사용할 시간 관련 필드들은 재사용성이 높기 때문에 `CommonTimeEntity` 로 뺐습니다.

# 변경 사항

- DB User Table -> `is_active`, `phone_number` 제거
- `CommonTimeEntity` 생성

# 질문 사항

질문 사항들을 적어주세요

# 기타

그 외로 적고 싶은 내용을 적어주세요

# (Optaionl) 어떻게 테스트하셨나요?



